### PR TITLE
Fix UnAuthenticated API call from frontend, Optimise Tanstack Query usage

### DIFF
--- a/client/src/components/InputPage/TransactionTable/TransactionTable.tsx
+++ b/client/src/components/InputPage/TransactionTable/TransactionTable.tsx
@@ -1,6 +1,5 @@
 import { useParams } from "react-router-dom";
 import "./TransactionTable.css";
-import { useEffect, useState } from "react";
 import TanstackTable from "./TanstackTable/TanstackTable";
 import { useQuery } from "@tanstack/react-query";
 import { useAppSelector } from "../../../hooks";
@@ -15,41 +14,34 @@ export type Transaction = {
 
 function TransactionTable() {
   const params = useParams();
-  const [transactionData, setTransactionData] = useState<Transaction[]>();
-  const [isLoaded, setIsLoaded] = useState<Boolean>(false);
 
   const auth = useAppSelector((state) => state.auth);
 
-  const fetchTransactionData = async () => {
-    const res = await fetch(
-      `${process.env.REACT_APP_SERVER_URL}/api/transaction/get/${params.id}`,
-      {
-        method: "GET",
-        headers: {
-          "Content-type": "application/json",
-          Authorization: `Bearer ${auth.token}`,
-        },
-      }
-    );
-    return res.json();
-  };
+  const fetchTransactionData = () =>
+    auth.user.id
+      ? fetch(
+          `${process.env.REACT_APP_SERVER_URL}/api/transaction/get/${params.id}`,
+          {
+            method: "GET",
+            headers: {
+              "Content-type": "application/json",
+              Authorization: `Bearer ${auth.token}`,
+            },
+          }
+        )
+          .then((res) => res.json())
+          .then((data) => data.transaction_data)
+      : [];
 
   const { data, status } = useQuery(
-    ["getTransactionData"],
+    ["getTransactionData", auth],
     fetchTransactionData
   );
 
-  useEffect(() => {
-    if (status === "success") {
-      setTransactionData(data.transaction_data);
-      setIsLoaded(true);
-    }
-  }, [status, data]);
-
   return (
     <div>
-      {isLoaded ? (
-        <TanstackTable transactionData={transactionData as Transaction[]} />
+      {status === "success" ? (
+        <TanstackTable transactionData={data as Transaction[]} />
       ) : (
         <h1 className="loading-text">Loading...</h1>
       )}

--- a/server/src/controllers/group.controller.ts
+++ b/server/src/controllers/group.controller.ts
@@ -28,8 +28,6 @@ const joinGroup = async (req: Request, res: Response, next: NextFunction) => {
   });
 };
 
-// group id still vulnerable to IDOR,
-// Need to fix group members table first
 const getHistory = async (req: Request, res: Response) => {
   const admin = res.locals.user;
   const data = await groupService.getHistory(Number(admin));
@@ -39,6 +37,7 @@ const getHistory = async (req: Request, res: Response) => {
   });
 };
 
+// TODO: Group ID IDOR fix
 const getMembers = async (req: Request, res: Response) => {
   const group_id = req.params.group_id;
   const data = await groupService.getMembers(Number(group_id));

--- a/server/src/controllers/transaction.controller.ts
+++ b/server/src/controllers/transaction.controller.ts
@@ -2,8 +2,7 @@ import { Request, Response } from "express";
 import transactionService from "../services/transaction.service";
 
 
-// transaction id still vulnerable to IDOR, 
-// Need to fix group members table first
+// TODO: group id IDOR vuln.
 const addTransaction = async (req: Request, res: Response) => {
   const { payment_of, amount, benefactor, group } = req.body.formData;
   const spender = res.locals.user


### PR DESCRIPTION
- Fix Unauthenticated API calls on group detail page on reloading that crashed the frontend
- Remove unnecessary `useEffect`, `useState` hooks used along with Tanstack Query